### PR TITLE
Compatibility with Factorissimo 3 (factorissimo-2-notnotmelon)

### DIFF
--- a/info.json
+++ b/info.json
@@ -18,7 +18,6 @@
     "(?) Krastorio2",
     "(?) Krastorio2-spaced-out",
     "(?) alien-biomes",
-    "! factorissimo-2-notnotmelon",
     "! lane-filtered-loaders",
     "! loaders-make-full-stacks"
   ]

--- a/scripts/surface-generation.lua
+++ b/scripts/surface-generation.lua
@@ -87,7 +87,7 @@ end
 dw.update_surfaces_properties = update_surfaces_properties
 
 local function surface_deleted(event)
-    if event.surface_index == storage.warp.previous.surface_index then
+    if storage.warp.previous and event.surface_index == storage.warp.previous.surface_index then
         local planet = game.planets[storage.warp.current.planet]
         if not planet.prototype.entities_require_heating then
             planet.associate_surface(storage.warp.current.surface)

--- a/scripts/warp.lua
+++ b/scripts/warp.lua
@@ -16,6 +16,7 @@ local function ignore_planet(planet)
     if planet == "nauvis" then return true end
     -- ignore specials surface frm the mod
     if dw.safe_surfaces[planet] then return true end
+    if planet:match('.*%-factory%-floor') or planet:match('factory%s-travel%s-surface') then return true end
     return false
 end
 


### PR DESCRIPTION
I got [Factorissimo 3](https://github.com/notnotmelon/factorissimo-2-notnotmelon) to add some fixes ([pr](https://github.com/notnotmelon/factorissimo-2-notnotmelon/pull/246)) that should make it compatible with Dimension Warp using the minor changes I made in this PR:
- remove the incompatibility wit Factorissimo 3 in the info.json
- removed factory floors and factory travel surfaces as valid warp destination
- fixed?? (might have been my own messing the save files and not an actual bug) an issue where the previous surfaces was not set, resulting in a crash when warping because we tried to dereference the previous surface to delete it

Note:
- I did not change the mod version in the info.json
- while I did test a few scenarios, I can't guarantee that this will work 100% of the time for all scenarios, but thanks to the PR that got merged on Factorissimo and this one, I managed to fix the issue where factories where corrupted/crashed when moving from any of Produtia, Smeltus or Electria to the Surface (Neo nauvis or any other planet), I made Neo Nauvis a valid factory floor, and Neo Nauvis and Electria have now Water as a resource for the Borehole.
- factories still require the same planet kind to operate, a factory created on Neo Nauvis will not work on Fulgora when warped, but will work again when warped back on Neo Nauvis