### PR TITLE
Added bobs compatibility

### DIFF
--- a/prototypes/entities/factory-beacon.lua
+++ b/prototypes/entities/factory-beacon.lua
@@ -232,6 +232,7 @@ base.drawing_box = {{-2, -2}, {2, 2}}
 base.energy_usage = "20MW"
 base.placeable_by = nil
 base.fast_replaceable_group = "factory-beacon"
+base.next_upgrade = nil
 base.allowed_effects = {"consumption", "speed", "pollution", "productivity", "quality"}
 
 ------------------------


### PR DESCRIPTION
Bobs changes the base beacon to have a next upgrade. This line of code prevents that change from affecting the factory beacon. Will probably also cause some other compatibilities.